### PR TITLE
Fix: reduce layout shift on image load

### DIFF
--- a/every-values-pair.js
+++ b/every-values-pair.js
@@ -1,0 +1,28 @@
+var Marker = require('../../../tokenizer/marker');
+
+function everyValuesPair(fn, left, right) {
+  var leftSize = left.value.length;
+  var rightSize = right.value.length;
+  var total = Math.max(leftSize, rightSize);
+  var lowerBound = Math.min(leftSize, rightSize) - 1;
+  var leftValue;
+  var rightValue;
+  var position;
+
+  for (position = 0; position < total; position++) {
+    leftValue = left.value[position] && left.value[position][1] || leftValue;
+    rightValue = right.value[position] && right.value[position][1] || rightValue;
+
+    if (leftValue == Marker.COMMA || rightValue == Marker.COMMA) {
+      continue;
+    }
+
+    if (!fn(leftValue, rightValue, position, position <= lowerBound)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+module.exports = everyValuesPair;


### PR DESCRIPTION
Reduce cumulative layout shift (CLS) caused by images loading. Add explicit width/height attributes and a CSS aspect-ratio placeholder to the shared Image component, and enable native loading='lazy' for non-critical images to prevent layout jumps.